### PR TITLE
Update simple audio queries only written response

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ SimplePhraseSpotter.cpp is a basic driver that uses an ALSA compatible microphon
     * Note you must prefix the ALSA device name with 'alsa:' when passing it to the simple spotter
 
 ### SimpleAudioQueriesOnlyWrittenResponse
-SimpleAudioQueriesOnlyWrittenResponse.cpp is another basic driver that uses an ALSA compatible microphone to listen for utterences of "Ok Hound" and responds only with text on the screen. **Note, it would not take much modification to make this driver support audio responses, most of the required changes would be inside the classes it uses not in the main .cpp file*
+SimpleAudioQueriesOnlyWrittenResponse.cpp is another basic driver that uses an ALSA compatible microphone to listen for utterences of "Ok Hound" and responds only with text on the screen. * *Note, it would not take much modification to make this driver support audio responses, most of the required changes would be inside the classes it uses not in the main .cpp file*
 
 ##### Basic Walkthrough
 1. After hearing "Ok Hound" the client beings an audio query. This includes, but is not limited to, preparing the request info, sending the request info, and starting to transmit audio data.
@@ -208,6 +208,20 @@ From here information about your client will be required, you can obtain this in
         cd ~/Downloads/HoundHouse/SimpleAudioQueriesOnlyWrittenResponse
         make -f Makefile.Rpi
 
+    * To build on a Raspberry Pi 3 B+ with support for the ReSpeaker 4 Mic Array's LED Ring use:
+
+        * First Build and install the WiringPi Library:
+
+                cd ~/Downloads
+                git clone git://git.drogon.net/wiringPi
+                cd wiringPi
+                ./build
+
+        * Build on a Raspberry Pi 3 B+, with ReSpeaker 4 Mic Array LED support:
+
+                cd ~/Downloads/HoundHouse/SimpleAudioQueriesOnlyWrittenResponse
+                make -f Makefile.Rpi -j 2 DEFINE_FEATURE_FLAGS='-DRESPEAKERLEDRING'
+
 * To find a device name to use run `arecord -L`
 
 * To run try:
@@ -216,3 +230,5 @@ From here information about your client will be required, you can obtain this in
         ./SimpleAudioQueriesOnlyWrittenResponse.out alsa:plughw:CARD=PCH,DEV=0
 
     * Note you must prefix the ALSA device name with 'alsa:' when passing it to the simple spotter
+    * If you compiled with WiringPi support you'll need to run with `sudo`, this is to get hardware access the GPIO port. I'm looking into ways to remove the need for the use of `sudo`.
+

--- a/SimpleAudioQueriesOnlyWrittenResponse/Makefile.Rpi
+++ b/SimpleAudioQueriesOnlyWrittenResponse/Makefile.Rpi
@@ -2,19 +2,21 @@ all: SimpleAudioQueriesOnlyWrittenResponse.out
 
 CPP=g++
 CPP_FLAGS= -Os -Wl,--no-keep-memory -Wl,--reduce-memory-overhead
-DEFNINE_DEBUG_FLAGS=
-#DEFNINE_DEBUG_FLAGS= -DHOUNDHOUSEDEBUG
+DEFINE_FEATURE_FLAGS=
+#DEFINE_FEATURE_FLAGS= -DRESPEAKERLEDRING
+DEFINE_DEBUG_FLAGS=
+#DEFINE_DEBUG_FLAGS= -DHOUNDHOUSEDEBUG
 LINK_CPP=g++
 LINK_FLAGS= -Os -Wl,--no-keep-memory -Wl,--reduce-memory-overhead -Wl,--export-dynamic
 
 SimpleAudioQueriesOnlyWrittenResponse.o LocalConfig.o: %.o: %.cpp
-	$(CPP) $(CPP_FLAGS) $(DEFNINE_DEBUG_FLAGS) -c $< -I../../HoundCpp/c_foundations -I../../HoundCpp/ReferenceCounting -I../../HoundCpp/SharedArray -I../../HoundCpp/Common -I../../HoundCpp/Numbers -I../../HoundCpp/SalmonEye -I../../HoundCpp/Utilities -I../../HoundCpp/GoldenRetriever -I../../HoundCpp/JSON -I../../HoundCpp/HoundJSON -I../../HoundCpp/HoundRequester -I../../HoundCpp/HoundConverser -I../../HoundCpp/ClientCapabilityRegistry -I../../HoundCpp -I../HoundifyExplorerUtils -I../OkHound/raspberrypi -I../SimpleHeaders -I../
+	$(CPP) $(CPP_FLAGS) $(DEFINE_FEATURE_FLAGS) $(DEFINE_DEBUG_FLAGS) -c $< -I../../HoundCpp/c_foundations -I../../HoundCpp/ReferenceCounting -I../../HoundCpp/SharedArray -I../../HoundCpp/Common -I../../HoundCpp/Numbers -I../../HoundCpp/SalmonEye -I../../HoundCpp/Utilities -I../../HoundCpp/GoldenRetriever -I../../HoundCpp/JSON -I../../HoundCpp/HoundJSON -I../../HoundCpp/HoundRequester -I../../HoundCpp/HoundConverser -I../../HoundCpp/ClientCapabilityRegistry -I../../HoundCpp -I../HoundifyExplorerUtils -I../OkHound/raspberrypi -I../SimpleHeaders -I../ $(if $(findstring -DRESPEAKERLEDRING,$(DEFINE_FEATURE_FLAGS)),-fopenmp)
 
 PlatformSpecificClientCapabilitiesLinux.o HoundClientALSAAudio.o: %.o: ../HoundifyExplorerUtils/%.cpp
-	$(CPP) $(CPP_FLAGS) $(DEFNINE_DEBUG_FLAGS) -c $< -I../../HoundCpp/c_foundations -I../../HoundCpp/ReferenceCounting -I../../HoundCpp/SharedArray -I../../HoundCpp/Common -I../../HoundCpp/Numbers -I../../HoundCpp/SalmonEye -I../../HoundCpp/Utilities -I../../HoundCpp/GoldenRetriever -I../../HoundCpp/JSON -I../../HoundCpp/HoundJSON -I../../HoundCpp/HoundRequester -I../../HoundCpp/HoundConverser -I../../HoundCpp/ClientCapabilityRegistry -I../../HoundCpp -I../HoundifyExplorerUtils
+	$(CPP) $(CPP_FLAGS) $(DEFINE_DEBUG_FLAGS) -c $< -I../../HoundCpp/c_foundations -I../../HoundCpp/ReferenceCounting -I../../HoundCpp/SharedArray -I../../HoundCpp/Common -I../../HoundCpp/Numbers -I../../HoundCpp/SalmonEye -I../../HoundCpp/Utilities -I../../HoundCpp/GoldenRetriever -I../../HoundCpp/JSON -I../../HoundCpp/HoundJSON -I../../HoundCpp/HoundRequester -I../../HoundCpp/HoundConverser -I../../HoundCpp/ClientCapabilityRegistry -I../../HoundCpp -I../HoundifyExplorerUtils
 
 SimpleAudioQueriesOnlyWrittenResponse.out: SimpleAudioQueriesOnlyWrittenResponse.o LocalConfig.o PlatformSpecificClientCapabilitiesLinux.o HoundClientALSAAudio.o
-	$(LINK_CPP) $(LINK_FLAGS) -o SimpleAudioQueriesOnlyWrittenResponse.out LocalConfig.o SimpleAudioQueriesOnlyWrittenResponse.o PlatformSpecificClientCapabilitiesLinux.o HoundClientALSAAudio.o -L../../HoundCpp/c_foundations -L../../HoundCpp/ReferenceCounting -L../../HoundCpp/SharedArray -L../../HoundCpp/Common -L../../HoundCpp/Numbers -L../../HoundCpp/SalmonEye -L../../HoundCpp/Utilities -L../../HoundCpp/GoldenRetriever -L../../HoundCpp/JSON -L../../HoundCpp/HoundJSON -L../../HoundCpp/HoundRequester -L../../HoundCpp/HoundConverser -L../../HoundCpp/ClientCapabilityRegistry -L../OkHound/raspberrypi -lclientcapabilityregistry -lhoundconverser -lhoundrequester -lhoundjson -ljson_library -lGoldenRetriever -lutilities -lSalmonEye -lnumbers -lc_foundations -lasound -lncurses -lpthread -ldl -lssl -lcrypto -lPhraseSpotter
+	$(LINK_CPP) $(LINK_FLAGS) -o SimpleAudioQueriesOnlyWrittenResponse.out LocalConfig.o SimpleAudioQueriesOnlyWrittenResponse.o PlatformSpecificClientCapabilitiesLinux.o HoundClientALSAAudio.o -L../../HoundCpp/c_foundations -L../../HoundCpp/ReferenceCounting -L../../HoundCpp/SharedArray -L../../HoundCpp/Common -L../../HoundCpp/Numbers -L../../HoundCpp/SalmonEye -L../../HoundCpp/Utilities -L../../HoundCpp/GoldenRetriever -L../../HoundCpp/JSON -L../../HoundCpp/HoundJSON -L../../HoundCpp/HoundRequester -L../../HoundCpp/HoundConverser -L../../HoundCpp/ClientCapabilityRegistry -L../OkHound/raspberrypi -lclientcapabilityregistry -lhoundconverser -lhoundrequester -lhoundjson -ljson_library -lGoldenRetriever -lutilities -lSalmonEye -lnumbers -lc_foundations -lasound -lncurses -lpthread -ldl -lssl -lcrypto -lPhraseSpotter $(if $(findstring -DRESPEAKERLEDRING,$(DEFINE_FEATURE_FLAGS)),-lwiringPi -lwiringPiDev -lm -lcrypt -lrt -lgomp -fopenmp)
 
 clean:
 	-rm -f SimpleAudioQueriesOnlyWrittenResponse.out SimpleAudioQueriesOnlyWrittenResponse.o LocalConfig.o PlatformSpecificClientCapabilitiesLinux.o HoundClientALSAAudio.o

--- a/SimpleHeaders/SimpleRequestInfoPreparer.h
+++ b/SimpleHeaders/SimpleRequestInfoPreparer.h
@@ -12,9 +12,45 @@
 
 class SimpleRequestInfoPreparer : public RequestInfoPreparer
 {
-  private:
+  protected:
+    const bool has_lat_to_use;
+    const double lat_to_use;
+    const bool has_lon_to_use;
+    const double lon_to_use;
+
   public:
     SimpleRequestInfoPreparer(void)
+      :
+        has_lat_to_use(false),
+        lat_to_use(0.0),
+        has_lon_to_use(false),
+        lon_to_use(0.0)
+    {
+    }
+
+    SimpleRequestInfoPreparer(
+      const double lat,
+      const double lon
+    )
+      :
+        has_lat_to_use(true),
+        lat_to_use(lat),
+        has_lon_to_use(true),
+        lon_to_use(lon)
+    {
+    }
+
+    SimpleRequestInfoPreparer(
+      const bool lat_passed,
+      const double lat,
+      const bool lon_passed,
+      const double lon
+    )
+      :
+        has_lat_to_use(lat_passed),
+        lat_to_use(lat),
+        has_lon_to_use(lon_passed),
+        lon_to_use(lon)
     {
     }
 
@@ -29,6 +65,20 @@ class SimpleRequestInfoPreparer : public RequestInfoPreparer
 #endif /* HOUNDHOUSEDEBUG */
 
       request_info->setServerDeterminesEndOfAudio(true);
+
+      if(has_lat_to_use){
+        request_info->setLatitude(lat_to_use);
+#ifdef HOUNDHOUSEDEBUG
+        std::cout<<"lat: "<<lat_to_use<<std::endl;
+#endif /* HOUNDHOUSEDEBUG */
+      }
+
+      if(has_lon_to_use){
+        request_info->setLongitude(lon_to_use);
+#ifdef HOUNDHOUSEDEBUG
+        std::cout<<"lon: "<<lon_to_use<<std::endl;
+#endif /* HOUNDHOUSEDEBUG */
+      }
 
 #ifdef HOUNDHOUSEDEBUG
       std::cout<<"Finished RequestInfoJSON preperations."<<std::endl;

--- a/SimpleHeaders/SimpleRequestInfoPreparer.h
+++ b/SimpleHeaders/SimpleRequestInfoPreparer.h
@@ -58,7 +58,7 @@ class SimpleRequestInfoPreparer : public RequestInfoPreparer
     {
     }
 
-    void prepare(RequestInfoJSON *request_info){
+    virtual void prepare(RequestInfoJSON *request_info){
       assert(request_info != NULL);
 #ifdef HOUNDHOUSEDEBUG
       std::cout<<"Beginning RequestInfoJSON preperations."<<std::endl;

--- a/SimpleHeaders/SimpleSinks.h
+++ b/SimpleHeaders/SimpleSinks.h
@@ -8,7 +8,9 @@
 #include "SimpleAudioVerifier.h"
 #include "SimplePartialHandler.h"
 
+#ifdef RESPEAKERLEDRING
 #include <wiringPi.h>
+#endif /* RESPEAKERLEDRING */
 
 class SimpleSinkWithoutClosingSound : public ClientCapabilityRegistry::DataSink
 {
@@ -41,6 +43,7 @@ class SimpleSinkWithoutClosingSound : public ClientCapabilityRegistry::DataSink
       }
 };
 
+#ifdef RESPEAKERLEDRING
 class SimpleSinkTurnOffLight : public SimpleSinkWithoutClosingSound
 {
   public:
@@ -69,4 +72,6 @@ class SimpleSinkTurnOffLight : public SimpleSinkWithoutClosingSound
       return byte_count;
     }
 };
+#endif /* RESPEAKERLEDRING */
+
 #endif /* SIMPLESINKS_H */


### PR DESCRIPTION
Added many new features:

Ability to pass Latitude and Longitude to the SimpleRequestInfoPreparer

Ability to pass --lat and --long flags to the ./SimpleAudioQueriesOnlyWrittenResponse executable

Added support for the ReSpeaker 4 Mic Array's LED ring 

Added a new simple sink named SimpleSinkTurnOffLight that will turn off the RESpeaker's 4 Mic Array when listening stops

Updated README to include instructions for compiling support for the ReSpeaker 4 Mic Array's LED ring 