### PR TITLE
Added a Base64 audio decoder

### DIFF
--- a/SimpleAudioQueries/Makefile.Rpi
+++ b/SimpleAudioQueries/Makefile.Rpi
@@ -2,8 +2,11 @@ all: SimpleAudioQueries.out
 
 CPP=g++
 CPP_FLAGS= -Os -Wl,--no-keep-memory -Wl,--reduce-memory-overhead
-DEFINE_FEATURE_FLAGS=
-#DEFINE_FEATURE_FLAGS= -DRESPEAKERLEDRING
+
+#DEFINE_FEATURE_FLAGS=
+DEFINE_FEATURE_FLAGS= -DWITHAUDIOOUTPUTFEATURES
+#DEFINE_FEATURE_FLAGS= -DRESPEAKERLEDRING -DWITHAUDIOOUTPUTFEATURES
+
 DEFINE_DEBUG_FLAGS=
 #DEFINE_DEBUG_FLAGS= -DHOUNDHOUSEDEBUG
 LINK_CPP=g++
@@ -15,8 +18,11 @@ SimpleAudioQueries.o LocalConfig.o: %.o: %.cpp
 PlatformSpecificClientCapabilitiesLinux.o HoundClientALSAAudio.o WAVAudioDecoder.o: %.o: ../HoundifyExplorerUtils/%.cpp
 	$(CPP) $(CPP_FLAGS) $(DEFINE_DEBUG_FLAGS) -c $< -I../../HoundCpp/c_foundations -I../../HoundCpp/ReferenceCounting -I../../HoundCpp/SharedArray -I../../HoundCpp/Common -I../../HoundCpp/Numbers -I../../HoundCpp/SalmonEye -I../../HoundCpp/Utilities -I../../HoundCpp/GoldenRetriever -I../../HoundCpp/JSON -I../../HoundCpp/HoundJSON -I../../HoundCpp/HoundRequester -I../../HoundCpp/HoundConverser -I../../HoundCpp/ClientCapabilityRegistry -I../../HoundCpp -I../HoundifyExplorerUtils
 
-SimpleAudioQueries.out: SimpleAudioQueries.o LocalConfig.o PlatformSpecificClientCapabilitiesLinux.o HoundClientALSAAudio.o WAVAudioDecoder.o
-	$(LINK_CPP) $(LINK_FLAGS) -o SimpleAudioQueries.out SimpleAudioQueries.o LocalConfig.o PlatformSpecificClientCapabilitiesLinux.o HoundClientALSAAudio.o WAVAudioDecoder.o -L../../HoundCpp/c_foundations -L../../HoundCpp/ReferenceCounting -L../../HoundCpp/SharedArray -L../../HoundCpp/Common -L../../HoundCpp/Numbers -L../../HoundCpp/SalmonEye -L../../HoundCpp/Utilities -L../../HoundCpp/GoldenRetriever -L../../HoundCpp/JSON -L../../HoundCpp/HoundJSON -L../../HoundCpp/HoundRequester -L../../HoundCpp/HoundConverser -L../../HoundCpp/ClientCapabilityRegistry -L../OkHound/raspberrypi -lclientcapabilityregistry -lhoundconverser -lhoundrequester -lhoundjson -ljson_library -lGoldenRetriever -lutilities -lSalmonEye -lnumbers -lc_foundations -lasound -lncurses -lpthread -ldl -lssl -lcrypto -lPhraseSpotter $(if $(findstring -DRESPEAKERLEDRING,$(DEFINE_FEATURE_FLAGS)),-lwiringPi -lwiringPiDev -lm -lcrypt -lrt -lgomp -fopenmp)
+SimpleDataSourceFromBase64EncodedString.o: %.o: ../SimpleHeaders/%.cpp
+	$(CPP) $(CPP_FLAGS) $(DEFINE_DEBUG_FLAGS) -c $< -I../../HoundCpp/c_foundations -I../../HoundCpp/ReferenceCounting -I../../HoundCpp/SharedArray -I../../HoundCpp/Common -I../../HoundCpp/Numbers -I../../HoundCpp/SalmonEye -I../../HoundCpp/Utilities -I../../HoundCpp/GoldenRetriever -I../../HoundCpp/JSON -I../../HoundCpp/HoundJSON -I../../HoundCpp/HoundRequester -I../../HoundCpp/HoundConverser -I../../HoundCpp/ClientCapabilityRegistry -I../../HoundCpp -I../HoundifyExplorerUtils
+
+SimpleAudioQueries.out: SimpleAudioQueries.o LocalConfig.o PlatformSpecificClientCapabilitiesLinux.o HoundClientALSAAudio.o WAVAudioDecoder.o $(if $(findstring -DWITHAUDIOOUTPUTFEATURES,$(DEFINE_FEATURE_FLAGS)), SimpleDataSourceFromBase64EncodedString.o)
+	$(LINK_CPP) $(LINK_FLAGS) -o SimpleAudioQueries.out SimpleAudioQueries.o LocalConfig.o PlatformSpecificClientCapabilitiesLinux.o HoundClientALSAAudio.o WAVAudioDecoder.o $(if $(findstring -DWITHAUDIOOUTPUTFEATURES,$(DEFINE_FEATURE_FLAGS)), SimpleDataSourceFromBase64EncodedString.o) -L../../HoundCpp/c_foundations -L../../HoundCpp/ReferenceCounting -L../../HoundCpp/SharedArray -L../../HoundCpp/Common -L../../HoundCpp/Numbers -L../../HoundCpp/SalmonEye -L../../HoundCpp/Utilities -L../../HoundCpp/GoldenRetriever -L../../HoundCpp/JSON -L../../HoundCpp/HoundJSON -L../../HoundCpp/HoundRequester -L../../HoundCpp/HoundConverser -L../../HoundCpp/ClientCapabilityRegistry -L../OkHound/raspberrypi -lclientcapabilityregistry -lhoundconverser -lhoundrequester -lhoundjson -ljson_library -lGoldenRetriever -lutilities -lSalmonEye -lnumbers -lc_foundations -lasound -lncurses -lpthread -ldl -lssl -lcrypto -lPhraseSpotter $(if $(findstring -DRESPEAKERLEDRING,$(DEFINE_FEATURE_FLAGS)),-lwiringPi -lwiringPiDev -lm -lcrypt -lrt -lgomp -fopenmp)
 
 clean:
-	-rm -f SimpleAudioQueries.out SimpleAudioQueries.o LocalConfig.o PlatformSpecificClientCapabilitiesLinux.o HoundClientALSAAudio.o WAVAudioDecoder.o
+	-rm -f SimpleAudioQueries.out SimpleAudioQueries.o LocalConfig.o PlatformSpecificClientCapabilitiesLinux.o HoundClientALSAAudio.o WAVAudioDecoder.o SimpleDataSourceFromBase64EncodedString.o

--- a/SimpleHeaders/SimpleDataSourceFromBase64EncodedString.cpp
+++ b/SimpleHeaders/SimpleDataSourceFromBase64EncodedString.cpp
@@ -1,0 +1,115 @@
+/* file "SimpleDataSourceFromBase64EncodedString.h" */
+
+#include "SimpleDataSourceFromBase64EncodedString.h"
+
+#include "ClientCapabilityRegistry.h"
+#include "Fetch.h"
+
+#include <cstdint>
+#include <cstring>
+#include <cassert>
+
+SimpleDataSourceFromBase64EncodedString::
+  SimpleDataSourceFromBase64EncodedString(
+    const char *data
+  )
+    :
+      data(data),
+      buffer_position(0)
+{
+  assert(data != NULL);
+  std::size_t length = strlen(data);
+  data_length = (length / 4) * 3;
+
+  /* Base64 must always use 4 bytes chunks, but this
+   * meansthat some times garbage = characters might be
+   * at the end of the string. These characters are used
+   * only to fill the last one or two bytes at the
+   * end. This is fine but we don't want to try to
+   * play the = character as sound.
+   */
+
+
+  if(data_length > 0){
+    if(data[length-1] == '='){
+      --data_length;
+      if(data[length-2] == '='){
+        --data_length;
+      }
+    }
+  }
+}
+
+SimpleDataSourceFromBase64EncodedString::
+  ~SimpleDataSourceFromBase64EncodedString(void)
+{
+}
+
+std::size_t SimpleDataSourceFromBase64EncodedString::
+  read_data(
+    std::uint8_t *input_data,
+    std::size_t byte_count
+  )
+{
+  assert(byte_count >= 0);
+
+  assert(buffer_position >= 0);
+  assert(buffer_position < 3);
+
+  if (byte_count == 0)
+      return 0;
+
+  std::uint8_t * data_remaining = input_data;
+  std::size_t byte_count_remaining = byte_count;
+  if (buffer_position > 0){
+    if (byte_count < 3 - buffer_position){
+      std::memcpy(input_data, &(byte_buffer[buffer_position]), byte_count);
+      buffer_position += byte_count;
+      assert(buffer_position < 3);
+      return byte_count;
+    }
+    std::memcpy(input_data, &(byte_buffer[buffer_position]), 3 - buffer_position);
+    byte_count_remaining -= 3 - buffer_position;
+    data_remaining += 3 - buffer_position;
+    buffer_position = 0;
+  }
+
+  assert(buffer_position == 0);
+
+  if (data_length >= 3 && byte_count_remaining >= 3){
+    std::size_t bulk_byte_count =
+      (data_length > byte_count_remaining) ?
+      byte_count_remaining :
+      data_length;
+    std::size_t chunk_count = bulk_byte_count / 3;
+    base64_decode(data, chunk_count * 4, data_remaining);
+    data_length -= chunk_count * 3;
+    data += chunk_count * 4;
+    byte_count_remaining -= chunk_count * 3;
+    data_remaining += chunk_count * 3;
+  }
+
+  if(data_length <= byte_count_remaining){
+    assert(data_length < 3);
+    if(data_length > 0){
+      base64_decode(data, 4, &(byte_buffer[0]));
+      std::memcpy(data_remaining, &(byte_buffer[0]), data_length);
+      data_length = 0;
+    }
+    return (data_remaining - input_data) + data_length;
+  }
+
+  buffer_position = byte_count_remaining;
+  assert(buffer_position < 3);
+  if (buffer_position > 0){
+    std::size_t to_decode =
+      (data_length >= 4) ? 4 : data_length;
+    base64_decode(data, 4, &(byte_buffer[0]));
+    data_length -= to_decode;
+    data += to_decode;
+    std::memcpy(data_remaining, &(byte_buffer[0]), buffer_position);
+    return byte_count;
+  }
+
+  return data_remaining - input_data;
+}

--- a/SimpleHeaders/SimpleDataSourceFromBase64EncodedString.h
+++ b/SimpleHeaders/SimpleDataSourceFromBase64EncodedString.h
@@ -1,0 +1,30 @@
+/* file "SimpleDataSourceFromBase64EncodedString.h" */
+
+#ifndef SIMPLEDATASOURCEFROMBASE64ENCODEDSTRING
+#define SIMPLEDATASOURCEFROMBASE64ENCODEDSTRING
+
+#include "ClientCapabilityRegistry.h"
+
+#include <cstdint>
+
+class SimpleDataSourceFromBase64EncodedString
+  :
+    public ClientCapabilityRegistry::DataSource
+{
+  private:
+    const char * data;
+    std::size_t data_length;
+    std::uint8_t byte_buffer[3];
+    std::size_t buffer_position;
+
+  public:
+    SimpleDataSourceFromBase64EncodedString(
+      const char *data
+    );
+
+    ~SimpleDataSourceFromBase64EncodedString(void);
+
+    std::size_t read_data(std::uint8_t *data, std::size_t byte_count);
+};
+
+#endif /* SIMPLEDATASOURCEFROMBASE64ENCODEDSTRING */

--- a/SimpleHeaders/SimpleDynamicResponseHandlers.h
+++ b/SimpleHeaders/SimpleDynamicResponseHandlers.h
@@ -3,15 +3,20 @@
 #ifndef SIMPLEDYNAMICRESPONSEHANDLERS_H
 #define SIMPLEDYNAMICRESPONSEHANDLERS_H
 
+#include "ClientCapabilityRegistry.h"
+
 #include "DynamicResponseHandler.h"
 #include "DynamicResponseJSON.h"
 #include "SimplePartialHandler.h"
+#ifdef WITHAUDIOOUTPUTFEATURES
+#include "SimpleDataSourceFromBase64EncodedString.h"
+#endif /* WITHAUDIOOUTPUTFEATURES */
 
 #include <iostream>
 
 class SimpleDynamicResponseHandlerWithNoAudioOutput : public DynamicResponseHandler
 {
-  private:
+  protected:
     bool saw_output;
     SimplePartialHandler * partial_handler;
 
@@ -38,12 +43,64 @@ class SimpleDynamicResponseHandlerWithNoAudioOutput : public DynamicResponseHand
         std::cerr<<"No response from server."<<std::endl;
     }
 
-    void handle(DynamicResponseJSON *dynamic_response){
+    virtual void handle(DynamicResponseJSON *dynamic_response){
       partial_handler->finishQuery();
       assert(dynamic_response != NULL);
+#ifdef HOUNDHOUSEDEBUG
+      std::cout<<"CommandKind: "<<dynamic_response->getCommandKind()<<std::endl;
+#endif /* HOUNDHOUSEDEBUG */
       std::cout<<"Response: "<<dynamic_response->getWrittenResponseLong()<<std::endl;
       saw_output = true;
     }
 };
+
+#ifdef WITHAUDIOOUTPUTFEATURES
+class SimpleDynamicResponseHandler : public SimpleDynamicResponseHandlerWithNoAudioOutput
+{
+  protected:
+    ClientCapabilityRegistry * capability_registry;
+    ClientCapabilityRegistry::AudioPlayer * audio_player_to_use;
+
+  public:
+    SimpleDynamicResponseHandler(
+      SimplePartialHandler * partial_handler,
+      ClientCapabilityRegistry * capability_registry,
+      ClientCapabilityRegistry::AudioPlayer * audio_player_to_use
+    )
+      :
+        SimpleDynamicResponseHandlerWithNoAudioOutput(partial_handler),
+        capability_registry(capability_registry),
+        audio_player_to_use(audio_player_to_use)
+    {
+    }
+
+    ~SimpleDynamicResponseHandler(void)
+    {
+    }
+
+    void handle(DynamicResponseJSON *dynamic_response){
+      SimpleDynamicResponseHandlerWithNoAudioOutput::handle(dynamic_response);
+      try {
+        if (dynamic_response->hasResponseAudioBytes()){
+          std::string audio_string =
+            dynamic_response->getResponseAudioBytes();
+          SimpleDataSourceFromBase64EncodedString data_source(audio_string.c_str());
+          capability_registry->lookup_audio_decoder("WAV")->play(
+            audio_player_to_use, &data_source
+          );
+        }
+      } catch (char *e1){
+        std::cerr << "Error handling audio output: "
+                  << e1
+                  << std::endl;
+        free(e1);
+      } catch (const char *e1){
+        std::cerr << "Error handling audio output: "
+                  << e1
+                  << std::endl;
+      }
+    }
+};
+#endif /* WITHAUDIOOUTPUTFEATURES */
 
 #endif /* SIMPLEDYNAMICRESPONSEHANDLERS_H */


### PR DESCRIPTION
I added a base64 audio decoder, this decoder will allow users to
translate the ResponseAudioBytes field that is included in a
Houndify.com response JSON. This code was created by taking great
inspiration from the HoundifyExplorer utility that does this.